### PR TITLE
Add support for referencing parent by maven coordinates

### DIFF
--- a/dev-resources/t_parent/samples/children/with_invalid_parent_coords/project.clj
+++ b/dev-resources/t_parent/samples/children/with_invalid_parent_coords/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-invalid-parent-coords "0.0.1"
+  :description "Child project that specifies invalid coords for a parent project"
+  :parent-project {:coords [lein-parent/does-not-exist "0.0.1"]
+                   :inherit [:foo]})

--- a/dev-resources/t_parent/samples/children/with_invalid_parent_path/project.clj
+++ b/dev-resources/t_parent/samples/children/with_invalid_parent_path/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-invalid-parent-path "0.0.1"
+  :description "Child project that specifies an invalid path for a parent project"
+  :parent-project {:path "../../parents/does_not_exist/project.clj"
+                   :inherit [:foo]})

--- a/dev-resources/t_parent/samples/children/with_no_parent_coords_or_path/project.clj
+++ b/dev-resources/t_parent/samples/children/with_no_parent_coords_or_path/project.clj
@@ -1,0 +1,3 @@
+(defproject child-with-no-parent-coords-or-path "0.0.1"
+  :description "Child project that doesn't specifies path or coords for parent"
+  :parent-project {:inherit [:foo]})

--- a/dev-resources/t_parent/samples/children/with_parent_coords/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_coords/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-parent-path "0.0.1"
+  :description "Child project that references parent project via coords"
+  :parent-project {:coords [lein-parent/parent-with-foo-property "0.0.1"]
+                   :inherit [:foo]})

--- a/dev-resources/t_parent/samples/children/with_parent_path/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_path/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-parent-path "0.0.1"
+  :description "Child project that references parent project via path"
+  :parent-project {:path "../../parents/with_foo_property/project.clj"
+                   :inherit [:foo]})

--- a/dev-resources/t_parent/samples/children/with_parent_with_managed_deps/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_with_managed_deps/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-parent-with-managed-deps "0.0.1"
+  :description "Child project that references parent project with managed dependencies"
+  :parent-project {:path "../../parents/with_managed_deps/project.clj"
+                   :inherit [:managed-dependencies]})

--- a/dev-resources/t_parent/samples/parents/with_foo_property/.gitignore
+++ b/dev-resources/t_parent/samples/parents/with_foo_property/.gitignore
@@ -1,0 +1,2 @@
+target
+pom.xml

--- a/dev-resources/t_parent/samples/parents/with_foo_property/project.clj
+++ b/dev-resources/t_parent/samples/parents/with_foo_property/project.clj
@@ -1,0 +1,3 @@
+(defproject lein-parent/parent-with-foo-property "0.0.1"
+  :description "Parent project that provides a property 'foo'"
+  :foo "foo")

--- a/dev-resources/t_parent/samples/parents/with_managed_deps/project.clj
+++ b/dev-resources/t_parent/samples/parents/with_managed_deps/project.clj
@@ -1,0 +1,4 @@
+(defproject lein-parent/parent-with-managed-deps "0.0.1"
+  :description "Parent project that provides managed dependencies"
+  :managed-dependencies [[clj-time "0.5.1"]
+                         [ring/ring-codec "1.0.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,10 @@
-(defproject lein-parent "0.2.2-SNAPSHOT"
+(defproject lein-parent "0.3.0-SNAPSHOT"
   :description "Leiningen plugin for inheriting properties from a parent project"
   :url "https://github.com/achin/lein-parent"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
+  :dependencies [[com.cemerick/pomegranate "0.3.1"]
+                 [org.codehaus.plexus/plexus-utils "3.0"]]
   :plugins [[lein-midje "3.1.3"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]]}})

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -1,6 +1,12 @@
 (ns leiningen.t-parent
   (:use [midje.sweet])
-  (:require [leiningen.parent :as p]))
+  (:require [leiningen.parent :as p]
+            [lein-parent.plugin :as plugin]
+            [clojure.test :refer :all]
+            [leiningen.core.project :as project]
+            [leiningen.install :as install])
+  (:import (java.io FileNotFoundException)
+           (org.sonatype.aether.resolution ArtifactResolutionException)))
 
 (def m {:a 1
         :b 2
@@ -25,3 +31,51 @@
                                                       :black :orange}}})
   (p/select-keys-in m [:a [:d 4]])   => (just {:a 1
                                                :d {4 :red}}))
+
+
+(defn test-proj-path
+  [kind proj-name]
+  (str "./dev-resources/t_parent/samples/" kind "/" proj-name "/project.clj"))
+
+(defn child-path
+  [proj-name]
+  (test-proj-path "children" proj-name))
+
+(defn parent-path
+  [proj-name]
+  (test-proj-path "parents" proj-name))
+
+(defn read-child-project
+  [proj-name]
+  (-> proj-name
+      child-path
+      project/read
+      plugin/middleware))
+
+(deftest parent-project-specification-test
+  (testing "Error thrown if neither path nor coords provided"
+    (is (thrown-with-msg? IllegalArgumentException #"must include either 'coords' or 'path'"
+          (read-child-project "with_no_parent_coords_or_path"))))
+  (testing "parent projects can be loaded by path"
+    (let [project (read-child-project "with_parent_path")]
+      (is (= "foo" (:foo project)))))
+  (testing "Error thrown if non-existent path provided"
+    (try
+      (read-child-project "with_invalid_parent_path")
+      ;; should not get here!
+      (is (true? false) "Exception should have been thrown by call to 'read-project'!")
+      (catch Exception e
+        (is (instance? FileNotFoundException (.getCause e))))))
+  (testing "parent projects can be loaded by coordinates"
+    (install/install (project/read (parent-path "with_foo_property")))
+    (let [project (read-child-project "with_parent_coords")]
+      (is (= "foo" (:foo project)))))
+  (testing "Error thrown if non-existent coords provided"
+    (is (thrown? ArtifactResolutionException
+          (read-child-project "with_invalid_parent_coords")))))
+
+(deftest inherited-values-test
+  (testing "managed_dependencies can be inherited from parent"
+    (let [project (read-child-project "with_parent_with_managed_deps")]
+      (is (= [['clj-time "0.5.1"] ['ring/ring-codec "1.0.1"]]
+             (:managed-dependencies project))))))


### PR DESCRIPTION
This commit adds support for referencing a parent project via its
maven coordinates, rather than via a file path.  It also adds
some test coverage for referencing parents via both mechanisms,
and validating that the 'managed-dependencies' section of the
parent project is merged properly.

This commit relies on a leiningen release that contains the following
patches (hopefully 2.7.0?):

https://github.com/technomancy/leiningen/pull/2164
https://github.com/technomancy/leiningen/pull/2126