### PR TITLE
Honor project's repositories when resolving parent coords

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -45,8 +45,10 @@
     (make-absolute root path)))
 
 (defn resolve-project-from-coords
-  [coords]
-  (let [resolved-parent-artifact (first (aether/resolve-artifacts :coordinates [coords]))
+  [coords repositories]
+  (let [resolved-parent-artifact (first (first (aether/resolve-dependencies
+                                                 :coordinates [coords]
+                                                 :repositories repositories)))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)]
     (project/init-project (project/read (InputStreamReader. (.getInputStream
@@ -57,7 +59,7 @@
   [project {:keys [path coords]}]
   (cond
     coords
-    (resolve-project-from-coords coords)
+    (resolve-project-from-coords coords (:repositories project))
 
     path
     (let [path (resolve-path (:root project) path)]

--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -1,6 +1,7 @@
 (ns leiningen.parent
   (:require [clojure.pprint :as pp]
             [leiningen.core.project :as project]
+            [leiningen.core.main :as main]
             [cemerick.pomegranate.aether :as aether])
   (:import (java.util.zip ZipFile)
            (java.io InputStreamReader)))
@@ -69,7 +70,7 @@
       (project/init-project (project/read path)))
 
     :else
-    (throw (IllegalArgumentException. "parent-project configuration must include either 'coords' or 'path'"))))
+    (main/warn "WARNING: :parent-project does not specify :coords or :path, so no parent project will be loaded.")))
 
 (defn parent-properties
   [proj ks]

--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -45,10 +45,11 @@
     (make-absolute root path)))
 
 (defn resolve-project-from-coords
-  [coords repositories]
+  [coords {:keys [repositories offline?]}]
   (let [resolved-parent-artifact (first (first (aether/resolve-dependencies
                                                  :coordinates [coords]
-                                                 :repositories repositories)))
+                                                 :repositories repositories
+                                                 :offline? offline?)))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)]
     (project/init-project (project/read (InputStreamReader. (.getInputStream
@@ -59,7 +60,9 @@
   [project {:keys [path coords]}]
   (cond
     coords
-    (resolve-project-from-coords coords (:repositories project))
+    (resolve-project-from-coords
+      coords
+      project)
 
     path
     (let [path (resolve-path (:root project) path)]

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -53,9 +53,6 @@
       plugin/middleware))
 
 (deftest parent-project-specification-test
-  (testing "Error thrown if neither path nor coords provided"
-    (is (thrown-with-msg? IllegalArgumentException #"must include either 'coords' or 'path'"
-          (read-child-project "with_no_parent_coords_or_path"))))
   (testing "parent projects can be loaded by path"
     (let [project (read-child-project "with_parent_path")]
       (is (= "foo" (:foo project)))))

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -6,7 +6,7 @@
             [leiningen.core.project :as project]
             [leiningen.install :as install])
   (:import (java.io FileNotFoundException)
-           (org.sonatype.aether.resolution ArtifactResolutionException)))
+           (org.sonatype.aether.resolution DependencyResolutionException)))
 
 (def m {:a 1
         :b 2
@@ -71,8 +71,8 @@
     (let [project (read-child-project "with_parent_coords")]
       (is (= "foo" (:foo project)))))
   (testing "Error thrown if non-existent coords provided"
-    (is (thrown? ArtifactResolutionException
-          (read-child-project "with_invalid_parent_coords")))))
+    (is (thrown? DependencyResolutionException
+                 (read-child-project "with_invalid_parent_coords")))))
 
 (deftest inherited-values-test
   (testing "managed_dependencies can be inherited from parent"


### PR DESCRIPTION
Prior to this commit, when the plugin was resolving the parent
project by it's maven coordinates, it did not pass any
repository info to aether.  This meant that aether would only
look in the user's .m2 cache, or on maven central, to try
to find the parent artifact.

This was problematic for projects whose parent project is published
to clojars or to a private maven artifact repository.

This commit grabs the repositories configuration from the child
project and includes it in the call to aether, allowing the
artifacts to be found from other places besides maven central.