### PR TITLE
Update :parent-project value to a map in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ For example:
                             [ring/ring-codec "1.0.1"]])
 
 (defproject superfun/kid-a "1.0.0-SNAPSHOT"
-   :parent-project [:coords [superfun/myparent "1.0.0"]
-                    :inherit [:managed-dependencies]]
+   :parent-project {:coords [superfun/myparent "1.0.0"]
+                    :inherit [:managed-dependencies]}
    :dependencies [[clj-time]
                   [me.raynes/fs]])
 
 (defproject superfun/kid-b "1.0.0-SNAPSHOT"
- :parent-project [:coords [superfun/myparent "1.0.0"]
-                  :inherit [:managed-dependencies]]
+ :parent-project {:coords [superfun/myparent "1.0.0"]
+                  :inherit [:managed-dependencies]}
  :dependencies [[clj-time]
                 [ring/ring-codec]])
 ```


### PR DESCRIPTION
The supplied multi-project example uses a vector for the :parent-project value.  It must be a map.  If a vector is used, the user is presented with a misleading warning which indicates that the :parent-project value does not specify :coords or :path.