### PR TITLE
Apply inherited profiles, fix for #3

### DIFF
--- a/dev-resources/t_parent/samples/children/with_parent_with_profile/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_with_profile/project.clj
@@ -1,0 +1,4 @@
+(defproject child-with-parent-with-profiles "0.0.1"
+  :description "Child project that references parent project with a profile"
+  :parent-project {:path "../../parents/with_profiles/project.clj"
+                   :inherit [[:profiles :foo]]})

--- a/dev-resources/t_parent/samples/parents/with_profiles/project.clj
+++ b/dev-resources/t_parent/samples/parents/with_profiles/project.clj
@@ -1,0 +1,3 @@
+(defproject lein-parent/parent-with-profile "0.0.1"
+  :description "Parent project that provides a profile to be inherited"
+  :profiles {:foo {:bar "bar"}})

--- a/src/lein_parent/plugin.clj
+++ b/src/lein_parent/plugin.clj
@@ -6,5 +6,6 @@
 
 (defn middleware [project]
   (if-let [inherited (parent/inherited-properties project)]
-    (meta-merge project inherited)
+    (with-meta (meta-merge project inherited)
+               (update (meta project) :profiles merge (:profiles inherited)))
     project))

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -75,4 +75,15 @@
   (testing "managed_dependencies can be inherited from parent"
     (let [project (read-child-project "with_parent_with_managed_deps")]
       (is (= [['clj-time "0.5.1"] ['ring/ring-codec "1.0.1"]]
-             (:managed-dependencies project))))))
+             (:managed-dependencies project)))))
+
+  (testing "profiles can be inherited from parent"
+    (testing "when the profile is activated"
+      ;; with-profiles calls the set-profiles function to 'activate' selected profiles
+      (let [project (project/set-profiles (read-child-project "with_parent_with_profile") [:foo])]
+        (is (= "bar" (:bar project)))))
+    (testing "when the profile is not activated, the profile is still available in the project"
+      ;; with-profiles calls the set-profiles function to 'activate' selected profiles
+      (let [project (read-child-project "with_parent_with_profile")]
+        (is (nil? (:bar project)))
+        (is (= "bar" (get-in project [:profiles :foo :bar])))))))


### PR DESCRIPTION
Apply any inherited profiles.
In order to ensure leiningen applies any profiles that may be inherited from the parent, then the inherited profiles just need to be explicitly merged into the profiles map of the `(meta project)`.