### PR TITLE
Use META-INF project.clj to resolve parent coord path for Lein 2.8.0.

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -52,10 +52,11 @@
                                                  :repositories repositories
                                                  :offline? offline?)))
         artifact-jar (:file (meta resolved-parent-artifact))
-        artifact-zip (ZipFile. artifact-jar)]
+        artifact-zip (ZipFile. artifact-jar)
+        project-clj-path (format "META-INF/leiningen/%s/project.clj" (first coords))]
     (project/init-project (project/read (InputStreamReader. (.getInputStream
                                           artifact-zip
-                                          (.getEntry artifact-zip "project.clj")))))))
+                                          (.getEntry artifact-zip project-clj-path)))))))
 
 (defn get-parent-project
   [project {:keys [path coords]}]

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -5,8 +5,7 @@
             [clojure.test :refer :all]
             [leiningen.core.project :as project]
             [leiningen.install :as install])
-  (:import (java.io FileNotFoundException)
-           (org.sonatype.aether.resolution DependencyResolutionException)))
+  (:import (java.io FileNotFoundException)))
 
 (def m {:a 1
         :b 2
@@ -68,8 +67,8 @@
     (let [project (read-child-project "with_parent_coords")]
       (is (= "foo" (:foo project)))))
   (testing "Error thrown if non-existent coords provided"
-    (is (thrown? DependencyResolutionException
-                 (read-child-project "with_invalid_parent_coords")))))
+    (is (thrown-with-msg? Exception #"Could not find artifact lein-parent:does-not-exist"
+                         (read-child-project "with_invalid_parent_coords")))))
 
 (deftest inherited-values-test
   (testing "managed_dependencies can be inherited from parent"


### PR DESCRIPTION
[Due to removal of project.clj from a jar's root in Lein 2.8.0-rc](https://github.com/technomancy/leiningen/commit/3679ba26497f60f2a2c6465156ca232b6276c2bc) on, this change uses the project.clj written to META-INF to resolve a parent's coordinates.  This should work in jars built with anything post Lein 2.0.0.

Test update as well as there was an [Aether namespace change for DependencyResolutionException](https://github.com/technomancy/leiningen/commit/c968fa5068fafadaca7eebf12391f691fcf2279d#diff-1b54638ff94371cd423868a08dfee7f8R12) that broke an import for tests in Lein 2.8.0-rc on.

Tested with Lein 2.7.1, and Lein 2.8.1.
