### PR TITLE
Resolve #16

### DIFF
--- a/dev-resources/t_parent/samples/children/with_parent_profile_plugin/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_profile_plugin/project.clj
@@ -1,0 +1,5 @@
+(defproject child-with-parent-profile-plugin "0.0.1"
+  :description "Child project that references parent project with profile plugins"
+  :dependencies [[medley "1.0.0"]]
+  :parent-project {:coords  [lein-parent/parent-with-profile-plugin "0.0.1"]
+                   :inherit [:dependencies [:profiles :dev]]})

--- a/dev-resources/t_parent/samples/parents/with_profile_plugin/project.clj
+++ b/dev-resources/t_parent/samples/parents/with_profile_plugin/project.clj
@@ -1,0 +1,6 @@
+(defproject lein-parent/parent-with-profile-plugin "0.0.1"
+  :description "Parent project that provides profile plugins"
+  :dependencies [[org.clojure/clojure "1.9.0"]]
+  :exclusions [org.clojure/clojure
+               org.clojure/clojurescript]
+  :profiles {:dev {:plugins [[venantius/ultra "0.5.2"]]}})

--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -52,10 +52,10 @@
 
 (defn resolve-project-from-coords
   [coords {:keys [repositories offline? update checksum]}]
-  (let [resolved-parent-artifact (ffirst (aether/resolve-dependencies
-                                           :coordinates [coords]
-                                           :repositories (map (partial update-policies update checksum) repositories)
-                                           :offline? offline?))
+  (let [resolved-parent-artifact (first (aether/resolve-artifacts
+                                          :coordinates [coords]
+                                          :repositories (map (partial update-policies update checksum) repositories)
+                                          :offline? offline?))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)
         project-clj-path (format "META-INF/leiningen/%s/project.clj" (first coords))]

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -68,7 +68,11 @@
       (is (= "foo" (:foo project)))))
   (testing "Error thrown if non-existent coords provided"
     (is (thrown-with-msg? Exception #"Could not find artifact lein-parent:does-not-exist"
-                         (read-child-project "with_invalid_parent_coords")))))
+                         (read-child-project "with_invalid_parent_coords"))))
+  (testing "parent projects can be loaded by coordinates and contain dev plugins"
+    (install/install (project/read (parent-path "with_profile_plugin")))
+    (let [project (read-child-project "with_parent_profile_plugin")]
+      (is (= [['venantius/ultra "0.5.2"]] (get-in project [:profiles :dev :plugins]))))))
 
 (deftest inherited-values-test
   (testing "managed_dependencies can be inherited from parent"


### PR DESCRIPTION
We had an issue using our parent `project.clj` when resolved from clojars which contained profile plugins. 

`lein-parent` was throwing NullPointers because it couldn't resolve the `project.clj` within the another dependencies jar.

`aether/resolve-dependencies` returned the dependency hierarchy correctly, but the `ffirst` to get the coords was some other dependency (presumably from the dev plugin).