### PR TITLE
check for alternate project.clj path

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -58,10 +58,12 @@
                                           :offline? offline?))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)
-        project-clj-path (format "META-INF/leiningen/%s/project.clj" (first coords))]
+        project-clj-path-1 (format "META-INF/leiningen/%s/project.clj" (first coords))
+        project-clj-path-2 (format "META-INF/leiningen/%s/%s/project.clj" (first coords) (first coords))]
     (project/init-project (project/read (InputStreamReader. (.getInputStream
                                           artifact-zip
-                                          (.getEntry artifact-zip project-clj-path)))))))
+                                          (or (.getEntry artifact-zip project-clj-path-1)
+                                              (.getEntry artifact-zip project-clj-path-2))))))))
 
 (defn get-parent-project
   [project {:keys [path coords]}]


### PR DESCRIPTION
I'm not sure why there's a difference, but leiningen creates all my jars with the namespace repeated twice, causing project.clj to not be found. I've added code to check both paths and use the entry it actually finds, so it should still work for anyone it already worked for, but will also work in our case (which I've seen described elsewhere as well, so should apply to others). 