### PR TITLE
Use classpath/add-repo-auth before passing repos to aether

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -2,6 +2,7 @@
   (:require [clojure.pprint :as pp]
             [leiningen.core.project :as project]
             [leiningen.core.main :as main]
+            [leiningen.core.classpath :as classpath]
             [cemerick.pomegranate.aether :as aether])
   (:import (java.util.zip ZipFile)
            (java.io InputStreamReader)))
@@ -54,7 +55,8 @@
   [coords {:keys [repositories offline? update checksum]}]
   (let [resolved-parent-artifact (first (aether/resolve-artifacts
                                           :coordinates [coords]
-                                          :repositories (map (partial update-policies update checksum) repositories)
+                                          :repositories (map (comp (partial update-policies update checksum) classpath/add-repo-auth)
+                                                             repositories)
                                           :offline? offline?))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)


### PR DESCRIPTION
Trying to pull from a private Artifactory failed, given a Leiningen configuration in which the user's profile.clj has this setup:

```
{ ... {:auth {:repository-auth {#"repo" {:url ... :username ... :password ...}}}
       {:repositories [[name url]]}
 ... }
```

Artifactory logs showed that the request for the parent project came without authentication.

This change passes the :repositories value of the project through `leiningen.core.classpath/add-repo-auth`, which appears to be what Leiningen does for itself, before calling `aether/resolve-artifacts`.